### PR TITLE
UserId property changed to Id

### DIFF
--- a/Backend/Backend/Models/Authentication/AuthenticationResult.cs
+++ b/Backend/Backend/Models/Authentication/AuthenticationResult.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Backend.Models.Authentication
+﻿namespace Backend.Models.Authentication
 {
     public class AuthenticationResult
     {
         public string UserType { get; set; }
-        public int UserId { get; set; }
+        public int Id { get; set; }
         public string Token { get; set; }
     }
 }

--- a/Backend/Backend/Services/AuthenticationService/AccountService.cs
+++ b/Backend/Backend/Services/AuthenticationService/AccountService.cs
@@ -124,7 +124,7 @@ namespace Backend.Services.AuthenticationService
                     serviceResponse.Data = new AuthenticationResult()
                     {
                         UserType = userRole,
-                        UserId = user.Id,
+                        Id = user.Id,
                         Token = new JwtSecurityTokenHandler().WriteToken(token),
                     };
                 }


### PR DESCRIPTION
As mentioned in the Issue on specification repository - Property name changed from UserId to Id in the AuthenticationResults object to allow for greater flexibility.